### PR TITLE
Fixed issue with role index that kept incrementing every time ngOnChan…

### DIFF
--- a/projects/angular-google-charts/src/lib/google-chart/google-chart.component.ts
+++ b/projects/angular-google-charts/src/lib/google-chart/google-chart.component.ts
@@ -113,7 +113,9 @@ export class GoogleChartComponent extends RawChartComponent implements OnInit, O
   private parseRoles(columnNames: any[]): any[] {
     const columnNamesWithRoles = columnNames.slice();
     if (this.roles) {
-      this.roles.forEach(role => {
+      // Roles must be copied to avoid modifying the index everytime there's a change from ngOnChanges.
+      const copyRoles = this.roles.map(role => Object.assign({}, role));
+      copyRoles.forEach(role => {
         const roleData: Role = {
           type: role.type,
           role: role.role
@@ -124,7 +126,7 @@ export class GoogleChartComponent extends RawChartComponent implements OnInit, O
         if (role.index != null) {
           columnNamesWithRoles.splice(role.index + 1, 0, roleData);
 
-          for (const otherRole of this.roles) {
+          for (const otherRole of copyRoles) {
             if (otherRole === role) {
               continue;
             }


### PR DESCRIPTION
Hello FERNman,

I've run into an issue where the role index of each role would increment every time ngOnChanges is called. The issue was the index property of each role in the roles array was incremented when parseRoles is called. To fix it I copy each role in the roles array to a new reference so it doesn't modify the original roles array but simply uses it as a temporary object.

This is causing the chart to display an error in the following image:
![index-error](https://user-images.githubusercontent.com/8919797/57560930-e1342100-733d-11e9-9bd6-9a4e982b9991.PNG)

This is what the array looks like after making a second pass on the parseRoles function. The tooltips are now out of order:
![index-increment](https://user-images.githubusercontent.com/8919797/57560952-032da380-733e-11e9-9c2f-af4193136845.PNG)

I hope you can accept this pull request or come up with your own solution for it. 

Thanks,
Alex