### PR TITLE
Fixed a type in the readme file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ resizing when the width of the parent changes.
 `google.visualization.ChartSpecs`
 
 ```html
-<raw-chart chartData="myChartData"></raw-chart>
+<raw-chart [chartData]="myChartData"></raw-chart>
 ```
 
 The chart data is an object that allows you to pass all chart configuration options at once. Please refer to the [Google documentation](https://developers.google.com/chart/interactive/docs/drawing_charts#chartwrapper) for more information. Everything you can pass to the ChartWrapper can be


### PR DESCRIPTION
surrounded chartData with brackets [ ]  in the example since it does not work without brackets.