### PR TITLE
updated chart version and provided injection token for chart version

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,25 @@ import { GoogleChartsModule } from 'angular-google-charts';
 export class AppModule {}
 ```
 
+If you want to use a specific version of Google Charts, you will need to provide a Maps API Key or an empty string for the first parameter and then the charts version as a string. This must be something like this: '45.2', '45', 'current', 'upcoming', etc... More information on this can be found in the [official documentation](https://developers.google.com/chart/interactive/docs/basic_load_libs).
+
+To do so, just add your chart version in the `GoogleChartsModule.forRoot()` method like this:
+
+```typescript
+import { GoogleChartsModule } from 'angular-google-charts';
+
+@NgModule({
+  ...
+  imports: [
+    ...
+    GoogleChartsModule.forRoot('my-custom-maps-api-key or not', 'chart-version'),
+    ...
+  ],
+  ...
+})
+export class AppModule {}
+```
+
 *Note:*
 
 It is not necessary to import the `GoogleChartsModule` by calling its `forRoot` method. You can simply import the module as well.

--- a/projects/angular-google-charts/src/lib/google-charts.module.ts
+++ b/projects/angular-google-charts/src/lib/google-charts.module.ts
@@ -3,14 +3,14 @@ import { NgModule, Provider, LOCALE_ID, ModuleWithProviders } from '@angular/cor
 import { ScriptLoaderService } from './script-loader/script-loader.service';
 import { RawChartComponent } from './raw-chart/raw-chart.component';
 import { GoogleChartComponent } from './google-chart/google-chart.component';
-import { GOOGLE_API_KEY } from './models/injection-tokens.model';
+import { GOOGLE_API_KEY, CHART_VERSION } from './models/injection-tokens.model';
 
 export const GOOGLE_CHARTS_PROVIDERS: Provider[] = [
   {
     provide: ScriptLoaderService,
     useFactory: setupScriptLoaderService,
     deps: [
-      LOCALE_ID, GOOGLE_API_KEY
+      LOCALE_ID, GOOGLE_API_KEY, CHART_VERSION
     ]
   }
 ];
@@ -29,17 +29,18 @@ export const GOOGLE_CHARTS_PROVIDERS: Provider[] = [
   ]
 })
 export class GoogleChartsModule {
-  public static forRoot(googleApiKey?: string): ModuleWithProviders {
+  public static forRoot(googleApiKey?: string, chartVersion?: string): ModuleWithProviders {
     return {
       ngModule: GoogleChartsModule,
       providers: [
         GOOGLE_CHARTS_PROVIDERS,
-        { provide: GOOGLE_API_KEY, useValue: googleApiKey ? googleApiKey : '' }
+        { provide: GOOGLE_API_KEY, useValue: googleApiKey ? googleApiKey : '' },
+        { provide: CHART_VERSION, useValue: chartVersion ? chartVersion : '46' }
       ]
     };
   }
 }
 
-export function setupScriptLoaderService(localeId: string, googleApiKey: string): ScriptLoaderService {
-  return new ScriptLoaderService(localeId, googleApiKey);
+export function setupScriptLoaderService(localeId: string, googleApiKey: string, chartVersion: string): ScriptLoaderService {
+  return new ScriptLoaderService(localeId, googleApiKey, chartVersion);
 }

--- a/projects/angular-google-charts/src/lib/models/injection-tokens.model.ts
+++ b/projects/angular-google-charts/src/lib/models/injection-tokens.model.ts
@@ -1,3 +1,4 @@
 import { InjectionToken } from '@angular/core';
 
+export const CHART_VERSION = new InjectionToken<string>('CHART_VERSION');
 export const GOOGLE_API_KEY = new InjectionToken<string>('GOOGLE_API_KEY');

--- a/projects/angular-google-charts/src/lib/script-loader/script-loader.service.ts
+++ b/projects/angular-google-charts/src/lib/script-loader/script-loader.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Inject, LOCALE_ID, Optional } from '@angular/core';
 import { Observable, Subject, of } from 'rxjs';
 
-import { GOOGLE_API_KEY } from '../models/injection-tokens.model';
+import { GOOGLE_API_KEY, CHART_VERSION } from '../models/injection-tokens.model';
 
 @Injectable()
 export class ScriptLoaderService {
@@ -11,7 +11,8 @@ export class ScriptLoaderService {
 
   constructor(
     @Inject(LOCALE_ID) private localeId: string,
-    @Inject(GOOGLE_API_KEY) @Optional() private googleApiKey?: string
+    @Inject(GOOGLE_API_KEY) @Optional() private googleApiKey?: string,
+    @Inject(CHART_VERSION) @Optional() private chartVersion?: string
   ) {
     this.initialize();
   }
@@ -50,7 +51,7 @@ export class ScriptLoaderService {
         mapsApiKey: this.googleApiKey
       };
 
-      google.charts.load('45.2', config);
+      google.charts.load(this.chartVersion, config);
       google.charts.setOnLoadCallback(() => {
         observer.next();
         observer.complete();


### PR DESCRIPTION
@FERNman - The demo loaded and works great but one test keeps failing on both version '45.2' and '46' so I'm not sure if this was an existing issue or not. Here's the image of the test:
![failed_test](https://user-images.githubusercontent.com/8919797/57950988-b7c74800-789d-11e9-89d0-9c15183bc401.PNG)
The google.visualization object doesn't seem to have the 'TreeMap' property. 

Thanks,
Alex