### PR TITLE
Clear charts

### DIFF
--- a/projects/angular-google-charts/src/lib/raw-chart/raw-chart.component.ts
+++ b/projects/angular-google-charts/src/lib/raw-chart/raw-chart.component.ts
@@ -90,9 +90,7 @@ export class RawChartComponent implements OnInit, OnChanges, AfterViewInit {
   }
 
   public clearChart(): void {
-    if(this.wrapper) {
-      this.wrapper.getChart().clearChart();
-    }
+    this.wrapper && this.wrapper.getChart() && this.wrapper.getChart().clearChart();
   }
 
   protected createChart() {

--- a/projects/angular-google-charts/src/lib/raw-chart/raw-chart.component.ts
+++ b/projects/angular-google-charts/src/lib/raw-chart/raw-chart.component.ts
@@ -89,6 +89,10 @@ export class RawChartComponent implements OnInit, OnChanges, AfterViewInit {
     return this.element.nativeElement.firstElementChild;
   }
 
+  public clearChart(): void {
+    this.wrapper.clearChart();
+  }
+
   protected createChart() {
     this.loadNeededPackages().subscribe(() => {
       this.wrapper = new google.visualization.ChartWrapper();

--- a/projects/angular-google-charts/src/lib/raw-chart/raw-chart.component.ts
+++ b/projects/angular-google-charts/src/lib/raw-chart/raw-chart.component.ts
@@ -90,7 +90,9 @@ export class RawChartComponent implements OnInit, OnChanges, AfterViewInit {
   }
 
   public clearChart(): void {
-    this.wrapper.clearChart();
+    if(this.wrapper) {
+      this.wrapper.getChart().clearChart();
+    }
   }
 
   protected createChart() {


### PR DESCRIPTION
Need to be able to clear charts for memory leak issues and/or also give users ability to display empty chart when there's no data. Otherwise we see a generic red banner coming from google charts.