### PR TITLE
Feature/formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,13 @@ passed here as well.
 This property is necessary when you want to create a raw chart that has the first row as data row. Defaults to false as for most charts the first row is the header row.
 
 #### Formatter
-`Array<{formatter: google.visualization.DefaultFormatter, colIndex: number}> | google.visualization.DefaultFormatter | Array<{formatterName: string, options: {}, colIndex: number}> | {formatterName: string, options: {}, colIndex: number}`
+`Array<{formatter: google.visualization.DefaultFormatter, colIndex: number}> | google.visualization.DefaultFormatter | Array<{formatterName: string, options: {}, colIndex: number}> | {formatterName: string, options: {}}`
 
 ```html
 <raw-chart [formatter]="myFormatter"></raw-chart>
 ```
 
-The `formatter` property is optional and allows to format the chart data. If you're only going to use the format() method available on all formatters, you just need to pass in an object with the desired formatter name and the option objects you wish to add. This formatter will be applied to all columns.
+The `formatter` property is optional and allows to format the chart data. If you don't want to deal with script loading and formatter instantiation in your application, you just need to pass in an object with the desired formatter name and the option objects you wish to add. This formatter will be applied to all columns.
 If you want to format specific columns, you can pass an array of objects where you have defined the formatter name, options and column index.
 
 ```typescript
@@ -124,6 +124,19 @@ myFormatter = [
   { formatterName: 'DateFormat', options:{formatType: 'long'}, colIndex: 1 },
   { formatterName: 'DateFormat', options: {formatType: 'long'}, colIndex: 3 }
 ];
+```
+*Note: The formatter name passed in should be the same as the formatter class name*.
+
+The Color Formatter is different from all the others because it doesn't take any options in its constructor. Instead it must be setup by calling addRange() or addGradientRange(). The options object for this formatter must start with a property called methodCall which takes a string with the name of the method to setup the formatter: 'AddRange' or 'AddGradientRange'.
+
+
+```typescript
+// Formats cells with values between 3 and 10
+myFormatter = {formatterName: 'ColorFormat', options: {methodCall: 'AddRange', from: 3, to: 10, color: '#FF0000', bgcolor: '#33FF33'}};
+
+// Formats cells with values between 3 and 10 with a gradient to indicate how close the value is from both limits 
+myFormatter = {formatterName: 'ColorFormat', options: {methodCall: 'AddRange', from: 3, to: 10, color: '#000000', fromBgColor: '#33FF33', toBgColor: '#FF0000'}};
+
 ```
 
 If you want to instantiate the formatters on your application you can do that. Simply pass in either a formatter class instance or an array of objects containing a formatter and an index.
@@ -141,7 +154,6 @@ For more information and all formatter types, please refer to the [documentation
 
 *Note1: When you get the error "google is not defined" whilst using the formatter in your component, you probably didn't load the script. Please see [CustomComponents](#custom-components)*.
 
-*Note2: The ColorFormat formatter is rather different from all others, the 'options' are not set via the constructor but calling the AddRange and AddGradientRange*.
 
 #### Dynamic Resize
 `boolean`

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ myFormatter = [
 
 For more information and all formatter types, please refer to the [documentation](https://google-developers.appspot.com/chart/interactive/docs/reference#formatters).
 
-*Note1: When you get the error "google is not defined" whilst using the formatter in your component, you probably didn't load the script. Please see [CustomComponents](#custom-components)*.
+*Note: When you get the error "google is not defined" whilst using the formatter in your component, you probably didn't load the script. Please see [CustomComponents](#custom-components)*.
 
 
 #### Dynamic Resize

--- a/README.md
+++ b/README.md
@@ -106,13 +106,27 @@ passed here as well.
 This property is necessary when you want to create a raw chart that has the first row as data row. Defaults to false as for most charts the first row is the header row.
 
 #### Formatter
-`Array<{formatter: google.visualization.DefaultFormatter, colIndex: number}> | google.visualization.DefaultFormatter`
+`Array<{formatter: google.visualization.DefaultFormatter, colIndex: number}> | google.visualization.DefaultFormatter | Array<{formatterName: string, options: {}, colIndex: number}> | {formatterName: string, options: {}, colIndex: number}`
 
 ```html
 <raw-chart [formatter]="myFormatter"></raw-chart>
 ```
 
-The `formatter` property is optional and allows to format the chart data. You can pass in either a formatter class instance or an array of objects containing a formatter and an index.
+The `formatter` property is optional and allows to format the chart data. If you're only going to use the format() method available on all formatters, you just need to pass in an object with the desired formatter name and the option objects you wish to add. This formatter will be applied to all columns.
+If you want to format specific columns, you can pass an array of objects where you have defined the formatter name, options and column index.
+
+```typescript
+// Formats all columns to Date(long)
+myFormatter = {formatterName: 'DateFormat', options: {formatType: 'long'}}
+
+// Formats the column with the index 1 and 3 to Date(long)
+myFormatter = [
+  { formatterName: 'DateFormat', options:{formatType: 'long'}, colIndex: 1 },
+  { formatterName: 'DateFormat', options: {formatType: 'long'}, colIndex: 3 }
+];
+```
+
+If you want to instantiate the formatters on your application you can do that. Simply pass in either a formatter class instance or an array of objects containing a formatter and an index.
 If passing a formatter class instance, every column will be formatted according to it. When passing in an array, you can specify which columns to format.
 
 ```typescript
@@ -125,7 +139,9 @@ myFormatter = [
 
 For more information and all formatter types, please refer to the [documentation](https://google-developers.appspot.com/chart/interactive/docs/reference#formatters).
 
-*Note: When you get the error "google is not defined" whilst using the formatter in your component, you probably didn't load the script. Please see [CustomComponents](#custom-components)*.
+*Note1: When you get the error "google is not defined" whilst using the formatter in your component, you probably didn't load the script. Please see [CustomComponents](#custom-components)*.
+
+*Note2: The ColorFormat formatter is rather different from all others, the 'options' are not set via the constructor but calling the AddRange and AddGradientRange*.
 
 #### Dynamic Resize
 `boolean`

--- a/projects/angular-google-charts/src/lib/helpers/google-chart-formatters.helper.ts
+++ b/projects/angular-google-charts/src/lib/helpers/google-chart-formatters.helper.ts
@@ -1,24 +1,15 @@
 // @dynamic
 export class GoogleChartsFormatterHelper {
-  private static formatters = {
-    'ArrowFormat': (options) => new google.visualization.ArrowFormat(options),
-    'BarFormat': (options) => new google.visualization.BarFormat(options),
-    'DateFormat': (options) => new google.visualization.DateFormat(options),
-    'NumberFormat': (options) => new google.visualization.NumberFormat(options),
-    'PatternFormat': (options) => new google.visualization.PatternFormat(options),
-    'ColorFormat': () => new google.visualization.ColorFormat()
-  };
-
   public static getFormatter(formatterName: string, options: any): google.visualization.DefaultFormatter {
-    if (Object.keys(this.formatters).indexOf(formatterName) === -1) {
+    if (!google.visualization.hasOwnProperty(formatterName)) {
       throw new Error('No formatter exists with the given name.');
     }
 
     if (formatterName === 'ColorFormat') {
-      return this.setupColorFormatter(this.formatters[formatterName](), options);
+      return this.setupColorFormatter(new google.visualization[formatterName], options);
     }
 
-    return  this.formatters[formatterName](options);
+    return  new google.visualization[formatterName](options);
   }
 
   private static setupColorFormatter(formatter: google.visualization.ColorFormat, options: any): google.visualization.ColorFormat {

--- a/projects/angular-google-charts/src/lib/helpers/google-chart-formatters.helper.ts
+++ b/projects/angular-google-charts/src/lib/helpers/google-chart-formatters.helper.ts
@@ -1,0 +1,18 @@
+import { throwError } from 'rxjs';
+
+export class GoogleChartsFormatterHelper {
+  private static formatters = {
+    'ArrowFormat': (options) => new google.visualization.ArrowFormat(options),
+    'BarFormat': (options) => new google.visualization.BarFormat(options),
+    'DateFormat': (options) => new google.visualization.DateFormat(options),
+    'NumberFormat': (options) => new google.visualization.NumberFormat(options),
+    'PatternFormat': (options) => new google.visualization.PatternFormat(options)
+  };
+
+  public static getFormatter(formatterName: string, options: any) {
+    if (Object.keys(this.formatters).indexOf(formatterName) === -1) {
+      throw new Error('No formatter exists with the given name.');
+    }
+    return  this.formatters[formatterName](options);
+  }
+}

--- a/projects/angular-google-charts/src/lib/helpers/google-chart-formatters.helper.ts
+++ b/projects/angular-google-charts/src/lib/helpers/google-chart-formatters.helper.ts
@@ -5,17 +5,41 @@ export class GoogleChartsFormatterHelper {
     'BarFormat': (options) => new google.visualization.BarFormat(options),
     'DateFormat': (options) => new google.visualization.DateFormat(options),
     'NumberFormat': (options) => new google.visualization.NumberFormat(options),
-    'PatternFormat': (options) => new google.visualization.PatternFormat(options)
+    'PatternFormat': (options) => new google.visualization.PatternFormat(options),
+    'ColorFormat': () => new google.visualization.ColorFormat()
   };
 
   public static getFormatter(formatterName: string, options: any): google.visualization.DefaultFormatter {
     if (Object.keys(this.formatters).indexOf(formatterName) === -1) {
       throw new Error('No formatter exists with the given name.');
     }
+
+    if (formatterName === 'ColorFormat') {
+      return this.setupColorFormatter(this.formatters[formatterName](), options);
+    }
+
     return  this.formatters[formatterName](options);
   }
 
-  public static listFormatterNames(): Array<string> {
-    return Object.keys(this.formatters);
+  private static setupColorFormatter(formatter: google.visualization.ColorFormat, options: any): google.visualization.ColorFormat {
+    switch (options.func) {
+      case 'AddRange':
+        formatter.addRange(options.from, options.to, options.color, options.bgcolor);
+        return formatter;
+      case 'AddGradientRange':
+        formatter.addGradientRange(options.from, options.to, options.color, options.fromBgColor, options.toBgColor);
+        return formatter;
+      default:
+        return formatter;
+    }
+  }
+
+  public static isInstance(formatter: any): boolean {
+    return formatter instanceof google.visualization.ArrowFormat ||
+      formatter instanceof google.visualization.BarFormat ||
+      formatter instanceof google.visualization.ColorFormat ||
+      formatter instanceof google.visualization.DateFormat ||
+      formatter instanceof google.visualization.NumberFormat ||
+      formatter instanceof google.visualization.PatternFormat;
   }
 }

--- a/projects/angular-google-charts/src/lib/helpers/google-chart-formatters.helper.ts
+++ b/projects/angular-google-charts/src/lib/helpers/google-chart-formatters.helper.ts
@@ -22,15 +22,15 @@ export class GoogleChartsFormatterHelper {
   }
 
   private static setupColorFormatter(formatter: google.visualization.ColorFormat, options: any): google.visualization.ColorFormat {
-    switch (options.func) {
+    switch (options['methodCall']) {
       case 'AddRange':
-        formatter.addRange(options.from, options.to, options.color, options.bgcolor);
+        formatter.addRange(options['from'], options['to'], options['color'], options['bgcolor']);
         return formatter;
       case 'AddGradientRange':
-        formatter.addGradientRange(options.from, options.to, options.color, options.fromBgColor, options.toBgColor);
+        formatter.addGradientRange(options['from'], options['to'], options['color'], options['fromBgColor'], options['toBgColor']);
         return formatter;
       default:
-        return formatter;
+        throw new Error('Incorrect method call for Color Formatter.');
     }
   }
 

--- a/projects/angular-google-charts/src/lib/helpers/google-chart-formatters.helper.ts
+++ b/projects/angular-google-charts/src/lib/helpers/google-chart-formatters.helper.ts
@@ -6,7 +6,7 @@ export class GoogleChartsFormatterHelper {
     }
 
     if (formatterName === 'ColorFormat') {
-      return this.setupColorFormatter(new google.visualization[formatterName], options);
+      return this.setupColorFormatter(new google.visualization[formatterName](), options);
     }
 
     return  new google.visualization[formatterName](options);

--- a/projects/angular-google-charts/src/lib/helpers/google-chart-formatters.helper.ts
+++ b/projects/angular-google-charts/src/lib/helpers/google-chart-formatters.helper.ts
@@ -1,5 +1,4 @@
-import { throwError } from 'rxjs';
-
+// @dynamic
 export class GoogleChartsFormatterHelper {
   private static formatters = {
     'ArrowFormat': (options) => new google.visualization.ArrowFormat(options),
@@ -9,10 +8,14 @@ export class GoogleChartsFormatterHelper {
     'PatternFormat': (options) => new google.visualization.PatternFormat(options)
   };
 
-  public static getFormatter(formatterName: string, options: any) {
+  public static getFormatter(formatterName: string, options: any): google.visualization.DefaultFormatter {
     if (Object.keys(this.formatters).indexOf(formatterName) === -1) {
       throw new Error('No formatter exists with the given name.');
     }
     return  this.formatters[formatterName](options);
+  }
+
+  public static listFormatterNames(): Array<string> {
+    return Object.keys(this.formatters);
   }
 }

--- a/projects/angular-google-charts/src/lib/raw-chart/raw-chart.component.ts
+++ b/projects/angular-google-charts/src/lib/raw-chart/raw-chart.component.ts
@@ -39,11 +39,11 @@ export class RawChartComponent implements OnInit, OnChanges, AfterViewInit {
       }>
     | {
         formatterName: string;
-        options: object;
+        options: any;
       }
     | Array<{
       formatterName: string;
-      options: object;
+      options: any;
       colIndex: number
       }>;
 
@@ -142,13 +142,22 @@ export class RawChartComponent implements OnInit, OnChanges, AfterViewInit {
   }
 
   protected formatData(dataTable: google.visualization.DataTable) {
+    let localFormatter: google.visualization.DefaultFormatter;
     if (this.formatter instanceof Array) {
       this.formatter.forEach(value => {
-        value.formatter.format(dataTable, value.colIndex);
+        localFormatter = value.formatter instanceof google.visualization.DefaultFormatter ?
+                         value.formatter :
+                         GoogleChartsFormatterHelper.getFormatter(value.formatterName, value.options);
+
+        localFormatter.format(dataTable, value.colIndex);
       });
     } else {
+      localFormatter = this.formatter instanceof google.visualization.DefaultFormatter ?
+                          this.formatter :
+                          GoogleChartsFormatterHelper.getFormatter(this.formatter.formatterName, this.formatter.options);
+
       for (let i = 0; i < dataTable.getNumberOfColumns(); i++) {
-        this.formatter.format(dataTable, i);
+        localFormatter.format(dataTable, i);
       }
     }
   }

--- a/projects/angular-google-charts/src/lib/raw-chart/raw-chart.component.ts
+++ b/projects/angular-google-charts/src/lib/raw-chart/raw-chart.component.ts
@@ -14,6 +14,7 @@ import {
 import { fromEvent, Observable } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 
+import { GoogleChartsFormatterHelper} from '../helpers/google-chart-formatters.helper';
 import { GoogleChartPackagesHelper } from '../helpers/google-chart-packages.helper';
 import { ChartErrorEvent, ChartEvent } from '../models/events.model';
 import { ScriptLoaderService } from '../script-loader/script-loader.service';
@@ -35,6 +36,15 @@ export class RawChartComponent implements OnInit, OnChanges, AfterViewInit {
     | Array<{
         formatter: google.visualization.DefaultFormatter;
         colIndex: number;
+      }>
+    | {
+        formatterName: string;
+        options: object;
+      }
+    | Array<{
+      formatterName: string;
+      options: object;
+      colIndex: number
       }>;
 
   @Input()

--- a/projects/angular-google-charts/src/lib/raw-chart/raw-chart.component.ts
+++ b/projects/angular-google-charts/src/lib/raw-chart/raw-chart.component.ts
@@ -39,11 +39,11 @@ export class RawChartComponent implements OnInit, OnChanges, AfterViewInit {
       }>
     | {
         formatterName: string;
-        options: any;
+        options: {};
       }
     | Array<{
       formatterName: string;
-      options: any;
+      options: {};
       colIndex: number
       }>;
 
@@ -145,21 +145,31 @@ export class RawChartComponent implements OnInit, OnChanges, AfterViewInit {
     let localFormatter: google.visualization.DefaultFormatter;
     if (this.formatter instanceof Array) {
       this.formatter.forEach(value => {
-        localFormatter = value.formatter instanceof google.visualization.DefaultFormatter ?
+        localFormatter = this.formatterIsProvided(value) ?
                          value.formatter :
                          GoogleChartsFormatterHelper.getFormatter(value.formatterName, value.options);
 
         localFormatter.format(dataTable, value.colIndex);
       });
     } else {
-      localFormatter = this.formatter instanceof google.visualization.DefaultFormatter ?
-                          this.formatter :
-                          GoogleChartsFormatterHelper.getFormatter(this.formatter.formatterName, this.formatter.options);
+      localFormatter = this.formatterIsProvided(this.formatter) ?
+                          this.formatter as google.visualization.DefaultFormatter :
+                          GoogleChartsFormatterHelper.getFormatter((this.formatter as {formatterName: string; options: {}}).formatterName,
+                            (this.formatter as {formatterName: string; options: {}}).options);
 
       for (let i = 0; i < dataTable.getNumberOfColumns(); i++) {
         localFormatter.format(dataTable, i);
       }
     }
+  }
+
+  private formatterIsProvided(formatter: any) {
+    return formatter instanceof google.visualization.ArrowFormat ||
+      formatter instanceof google.visualization.BarFormat ||
+      formatter instanceof google.visualization.ColorFormat ||
+      formatter instanceof google.visualization.DateFormat ||
+      formatter instanceof google.visualization.NumberFormat ||
+      formatter instanceof google.visualization.PatternFormat;
   }
 
   private addResizeListener() {

--- a/projects/angular-google-charts/src/lib/raw-chart/raw-chart.component.ts
+++ b/projects/angular-google-charts/src/lib/raw-chart/raw-chart.component.ts
@@ -145,14 +145,14 @@ export class RawChartComponent implements OnInit, OnChanges, AfterViewInit {
     let localFormatter: google.visualization.DefaultFormatter;
     if (this.formatter instanceof Array) {
       this.formatter.forEach(value => {
-        localFormatter = this.formatterIsProvided(value) ?
+        localFormatter = GoogleChartsFormatterHelper.isInstance(value) ?
                          value.formatter :
                          GoogleChartsFormatterHelper.getFormatter(value.formatterName, value.options);
 
         localFormatter.format(dataTable, value.colIndex);
       });
     } else {
-      localFormatter = this.formatterIsProvided(this.formatter) ?
+      localFormatter = GoogleChartsFormatterHelper.isInstance(this.formatter) ?
                           this.formatter as google.visualization.DefaultFormatter :
                           GoogleChartsFormatterHelper.getFormatter((this.formatter as {formatterName: string; options: {}}).formatterName,
                             (this.formatter as {formatterName: string; options: {}}).options);
@@ -161,15 +161,6 @@ export class RawChartComponent implements OnInit, OnChanges, AfterViewInit {
         localFormatter.format(dataTable, i);
       }
     }
-  }
-
-  private formatterIsProvided(formatter: any) {
-    return formatter instanceof google.visualization.ArrowFormat ||
-      formatter instanceof google.visualization.BarFormat ||
-      formatter instanceof google.visualization.ColorFormat ||
-      formatter instanceof google.visualization.DateFormat ||
-      formatter instanceof google.visualization.NumberFormat ||
-      formatter instanceof google.visualization.PatternFormat;
   }
 
   private addResizeListener() {

--- a/src/app/main/main.component.html
+++ b/src/app/main/main.component.html
@@ -8,6 +8,7 @@
     [columnNames]="chart.columnNames"
     [roles]="chart.roles"
     [options]="chart.options"
+    [formatter]="chart.formatter"
     (ready)="onReady()"
     (select)="onSelect($event)"
     (error)="onError($event)"

--- a/src/app/main/main.component.ts
+++ b/src/app/main/main.component.ts
@@ -16,6 +16,7 @@ export class MainComponent implements OnInit {
     roles: Array<{ type: string; role: string; index?: number }>;
     columnNames?: Array<string>;
     options?: {};
+    formatter?: {formatterName: string; options: {}} | Array<{formatterName: string; options: {}, colIndex: number}>;
   }> = [];
 
   public changingChart = {
@@ -134,7 +135,26 @@ export class MainComponent implements OnInit {
       type: 'AreaChart',
       columnNames: ['Year', 'Sales', 'Expenses'],
       data: [['2013', 1000, 400], ['2014', 1170, 460], ['2015', 660, 1120], ['2016', 1030, 540]],
-      roles: []
+      roles: [],
+      formatter: [{
+        formatterName: 'NumberFormat',
+        options: {
+          decimalSymbol: ',',
+          groupingSymbol: '.',
+          fractionDigits: 2,
+          suffix: '€'
+        },
+        colIndex: 1
+      }, {
+        formatterName: 'NumberFormat',
+        options: {
+          decimalSymbol: ',',
+          groupingSymbol: '.',
+          fractionDigits: 2,
+          suffix: '€'
+        },
+        colIndex: 2
+      }]
     });
 
     this.charts.push({


### PR DESCRIPTION
Hey there,

I've added a feature where instead of having to break the wrapper to expose the google variable to instantiate the formatters and then pass them into the google chart component, the user can simply pass in an object 

`{formatterName: string, options: {}}`

Or an array 

`Array<{formatterName: string, options: {}, colIndex: number}>`

This way the Angular Google Charts encapsulates the formatter instantiation and setup. I've maintained the option of passing in a formatter class instance or an array of class instances though.

I've also update the README with this info.

I think this provides a more seamless use of the API. Tell me what you think.

By the way thanks a lot for creating this, it's really useful!