### PR TITLE
fix: select event not firing

### DIFF
--- a/libs/angular-google-charts/src/lib/components/google-chart/google-chart.component.spec.ts
+++ b/libs/angular-google-charts/src/lib/components/google-chart/google-chart.component.spec.ts
@@ -265,7 +265,6 @@ describe('GoogleChartComponent', () => {
 
       expect(visualizationMock.events.addListener).toHaveBeenCalledWith(chartWrapperMock, 'ready', expect.any(Function));
       expect(visualizationMock.events.addListener).toHaveBeenCalledWith(chartWrapperMock, 'error', expect.any(Function));
-      expect(visualizationMock.events.addListener).toHaveBeenCalledWith(chartWrapperMock, 'select', expect.any(Function));
     });
   });
 
@@ -458,7 +457,7 @@ describe('GoogleChartComponent', () => {
       service.loadChartPackages.mockReturnValueOnce(of(null));
     });
 
-    it('should register mouse event handlers after the chart is drawn', () => {
+    it('should register chart event handlers after the chart got drawn', () => {
       const chartMock = { draw: jest.fn() };
       chartWrapperMock.getChart.mockReturnValue(chartMock);
 
@@ -466,12 +465,14 @@ describe('GoogleChartComponent', () => {
 
       expect(visualizationMock.events.addListener).not.toHaveBeenCalledWith(chartWrapperMock, 'onmouseover', expect.any(Function));
       expect(visualizationMock.events.addListener).not.toHaveBeenCalledWith(chartWrapperMock, 'onmouseout', expect.any(Function));
+      expect(visualizationMock.events.addListener).not.toHaveBeenCalledWith(chartWrapperMock, 'select', expect.any(Function));
 
       const readyCallback = visualizationMock.events.addListener.mock.calls[0][2];
       readyCallback();
 
       expect(visualizationMock.events.addListener).toHaveBeenCalledWith(chartMock, 'onmouseover', expect.any(Function));
       expect(visualizationMock.events.addListener).toHaveBeenCalledWith(chartMock, 'onmouseout', expect.any(Function));
+      expect(visualizationMock.events.addListener).toHaveBeenCalledWith(chartMock, 'select', expect.any(Function));
     });
 
     it('should remove all listeners from the chart before subscribing again', () => {
@@ -528,10 +529,12 @@ describe('GoogleChartComponent', () => {
 
       component.ngOnInit();
 
+      const readyCallback = visualizationMock.events.addListener.mock.calls[0][2];
+      readyCallback();
+
       expect(selectSpy).not.toHaveBeenCalled();
 
-      const selectCallback = visualizationMock.events.addListener.mock.calls[2][2];
-
+      const selectCallback = visualizationMock.events.addListener.mock.calls[4][2];
       selectCallback();
 
       expect(selectSpy).toHaveBeenCalledWith({ selection });

--- a/libs/angular-google-charts/src/lib/components/google-chart/google-chart.component.ts
+++ b/libs/angular-google-charts/src/lib/components/google-chart/google-chart.component.ts
@@ -282,15 +282,15 @@ export class GoogleChartComponent implements ChartBase, OnChanges, OnInit {
       google.visualization.events.removeAllListeners(this.chart);
       registerChartEvent(this.chart, 'onmouseover', (event: ChartMouseOverEvent) => this.mouseover.emit(event));
       registerChartEvent(this.chart, 'onmouseout', (event: ChartMouseLeaveEvent) => this.mouseleave.emit(event));
+      registerChartEvent(this.chart, 'select', () => {
+        const selection = this.chart.getSelection();
+        this.select.emit({ selection });
+      });
 
       this.ready.emit({ chart: this.chart });
     });
 
     registerChartEvent(this.wrapper, 'error', (error: ChartErrorEvent) => this.error.emit(error));
-    registerChartEvent(this.wrapper, 'select', () => {
-      const selection = this.chart.getSelection();
-      this.select.emit({ selection });
-    });
   }
 
   private drawChart() {


### PR DESCRIPTION
The Chart Wrapper no longer emits the charts' select event.

Resolves #136 