### PR TITLE
fix: no selector for directive error

### DIFF
--- a/libs/angular-google-charts/src/lib/components/chart-base/chart-base.component.ts
+++ b/libs/angular-google-charts/src/lib/components/chart-base/chart-base.component.ts
@@ -1,4 +1,4 @@
-import { Directive, EventEmitter, Output } from '@angular/core';
+import { EventEmitter } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { ChartErrorEvent, ChartReadyEvent, ChartSelectionChangedEvent } from '../../models/events.model';
@@ -6,22 +6,18 @@ import { ChartErrorEvent, ChartReadyEvent, ChartSelectionChangedEvent } from '..
 export type Column = string | google.visualization.ColumnSpec;
 export type Row = (string | number | Date)[];
 
-@Directive()
-// tslint:disable-next-line: directive-class-suffix
-export class ChartBase {
+export interface ChartBase {
   /**
    * The chart is ready for external method calls.
    *
    * Emits *after* the chart was drawn for the first time every time the chart gets redrawn.
    */
-  @Output()
-  public ready: EventEmitter<ChartReadyEvent>;
+  ready: EventEmitter<ChartReadyEvent>;
 
   /**
    * Emits when an error occurs when attempting to render the chart.
    */
-  @Output()
-  public error: EventEmitter<ChartErrorEvent>;
+  error: EventEmitter<ChartErrorEvent>;
 
   /**
    * Emits when the user clicks a bar or legend.
@@ -30,21 +26,20 @@ export class ChartBase {
    * in the data table is selected; when a legend is selected,
    * the corresponding column in the data table is selected.
    */
-  @Output()
-  public select: EventEmitter<ChartSelectionChangedEvent>;
+  select: EventEmitter<ChartSelectionChangedEvent>;
 
   /**
    * The drawn chart or `null`.
    */
-  public chart: google.visualization.ChartBase | null;
+  chart: google.visualization.ChartBase | null;
 
   /**
    * The underlying chart wrapper or `null`.
    */
-  public chartWrapper: google.visualization.ChartWrapper | null;
+  chartWrapper: google.visualization.ChartWrapper | null;
 
   /**
    * Emits after the `ChartWrapper` is created, but before the chart is drawn for the first time.
    */
-  public wrapperReady$: Observable<google.visualization.ChartWrapper>;
+  wrapperReady$: Observable<google.visualization.ChartWrapper>;
 }


### PR DESCRIPTION
Before Angular 9, empty directives were not supported.
The ChartBase is being used as an interface anyway.

Resolves #138 