### PR TITLE
fix: google-chart.component.ts dataTable is out of sync with input data

### DIFF
--- a/libs/angular-google-charts/src/lib/components/google-chart/google-chart.component.ts
+++ b/libs/angular-google-charts/src/lib/components/google-chart/google-chart.component.ts
@@ -214,6 +214,7 @@ export class GoogleChartComponent implements ChartBase, OnChanges, OnInit {
 
   private createDataTable() {
     if (this.data == null) {
+      this.dataTable = undefined;
       return;
     }
 


### PR DESCRIPTION
In case when input data is switched to null or undefined `ChartWrapper` is still using old `dataTable` and there is no error event.