### PR TITLE
fix: provide script-loader service in module

### DIFF
--- a/libs/angular-google-charts/src/lib/google-charts.module.ts
+++ b/libs/angular-google-charts/src/lib/google-charts.module.ts
@@ -7,9 +7,11 @@ import { DashboardComponent } from './components/dashboard/dashboard.component';
 import { GoogleChartComponent } from './components/google-chart/google-chart.component';
 import { GoogleChartsConfig } from './models/google-charts-config.model';
 import { GOOGLE_CHARTS_CONFIG } from './models/injection-tokens.model';
+import { ScriptLoaderService } from './script-loader/script-loader.service';
 
 @NgModule({
   declarations: [GoogleChartComponent, ChartWrapperComponent, DashboardComponent, ControlWrapperComponent, ChartEditorComponent],
+  providers: [ScriptLoaderService],
   exports: [GoogleChartComponent, ChartWrapperComponent, DashboardComponent, ControlWrapperComponent, ChartEditorComponent]
 })
 export class GoogleChartsModule {

--- a/libs/angular-google-charts/src/lib/script-loader/script-loader.service.ts
+++ b/libs/angular-google-charts/src/lib/script-loader/script-loader.service.ts
@@ -10,7 +10,7 @@ const DEFAULT_CONFIG: GoogleChartsConfig = {
   safeMode: false
 };
 
-@Injectable({ providedIn: 'root' })
+@Injectable()
 export class ScriptLoaderService {
   private readonly scriptSource = 'https://www.gstatic.com/charts/loader.js';
   private readonly scriptLoadSubject = new Subject<null>();


### PR DESCRIPTION
By providing the `ScriptLoaderService` in the module, the config injection token should work, even with lazy-loaded modules.

Resolves #162 