### PR TITLE
feat: added chart version lazy loading ability

### DIFF
--- a/libs/angular-google-charts/src/lib/services/script-loader.service.ts
+++ b/libs/angular-google-charts/src/lib/services/script-loader.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, LOCALE_ID, NgZone, Optional } from '@angular/core';
-import { Observable, of, Subject } from 'rxjs';
-import { switchMap } from 'rxjs/operators';
+import { isObservable, Observable, of, Subject } from 'rxjs';
+import { flatMap, switchMap } from 'rxjs/operators';
 
 import { GoogleChartsConfig, GOOGLE_CHARTS_CONFIG } from '../types/google-charts-config';
 
@@ -50,7 +50,8 @@ export class ScriptLoaderService {
    */
   public loadChartPackages(...packages: string[]): Observable<null> {
     return this.loadGoogleCharts().pipe(
-      switchMap(() => {
+      flatMap(() => (isObservable(this.config.version) ? this.config.version : of(this.config.version!))),
+      switchMap((chartVersion: string) => {
         return new Observable<null>(observer => {
           const config = {
             packages,
@@ -59,7 +60,7 @@ export class ScriptLoaderService {
             safeMode: this.config.safeMode
           };
 
-          google.charts.load(this.config.version!, config);
+          google.charts.load(chartVersion, config);
           google.charts.setOnLoadCallback(() => {
             this.zone.run(() => {
               observer.next();

--- a/libs/angular-google-charts/src/lib/types/google-charts-config.ts
+++ b/libs/angular-google-charts/src/lib/types/google-charts-config.ts
@@ -1,4 +1,5 @@
 import { InjectionToken } from '@angular/core';
+import { Observable } from 'rxjs';
 
 export interface GoogleChartsConfig {
   /**
@@ -19,15 +20,15 @@ export interface GoogleChartsConfig {
    * Please note that this library does only work with Google Charts 45 or higher.
    *
    * @description
-   * Can be either a number specifying a
+   * You can provide either a literal string or an observable that emits a string. The value can be either a number specifying a
    * {@link https://developers.google.com/chart/interactive/docs/release_notes#current:-january-6,-2020 frozen version } of Google Charts
    * or one of the special versions `current` and `upcoming`.
    *
    * Defaults to `current`.
    *
-   * {@link https://developers.google.com/chart/interactive/docs/basic_load_libs#basic-library-loading Offical Documentation}
+   * {@link https://developers.google.com/chart/interactive/docs/basic_load_libs#basic-library-loading Official Documentation}
    */
-  version?: string;
+  version?: string | Observable<string>;
 
   /**
    * When set to true, all charts and tooltips that generate HTML from user-supplied data will sanitize it


### PR DESCRIPTION
@FERNman What do you think about this implementation for the #175 feature request?

@learnuser521 Is this something that would help you? The idea is basically that the chart script doesn't load until the observable emits a chart version. I haven't been able to find a way to update the chart version after the chart script has been loaded since all the packages are loaded with whatever version you provide. I don't believe you can just manually delete the scripts and reload again since the previous charts/packages are already in memory and can't be overridden.