### PR TITLE
fix: loading correct package based on chart type

### DIFF
--- a/libs/angular-google-charts/src/lib/components/google-chart/google-chart.component.spec.ts
+++ b/libs/angular-google-charts/src/lib/components/google-chart/google-chart.component.spec.ts
@@ -280,6 +280,18 @@ describe('GoogleChartComponent', () => {
         expect.any(Function)
       );
     });
+
+    it('should create the chart with correct package', () => {
+      const service = TestBed.inject(ScriptLoaderService) as jest.Mocked<ScriptLoaderService>;
+      service.loadChartPackages.mockReturnValueOnce(of(null));
+
+      const chartType = ChartType.Map;
+      component.type = chartType;
+
+      component.ngOnInit();
+
+      expect(service.loadChartPackages).toHaveBeenCalledWith('map');
+    });
   });
 
   describe('ngOnChanges', () => {

--- a/libs/angular-google-charts/src/lib/components/google-chart/google-chart.component.ts
+++ b/libs/angular-google-charts/src/lib/components/google-chart/google-chart.component.ts
@@ -13,6 +13,7 @@ import {
 import { fromEvent, Observable, ReplaySubject, Subscription } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 
+import { getPackageForChart } from '../../helpers/chart.helper';
 import { DataTableService } from '../../services/data-table.service';
 import { ScriptLoaderService } from '../../services/script-loader.service';
 import { ChartType } from '../../types/chart-type';
@@ -162,10 +163,10 @@ export class GoogleChartComponent implements ChartBase, OnChanges, OnInit {
 
   public ngOnInit() {
     // We don't need to load any chart packages, the chart wrapper will handle this for us
-    this.scriptLoaderService.loadChartPackages().subscribe(() => {
+    this.scriptLoaderService.loadChartPackages(getPackageForChart(this.type)).subscribe(() => {
       this.dataTable = this.dataTableService.create(this.data, this.columns, this.formatters);
 
-      // Only ever create the wrapper once to allow animations to happen when someting changes.
+      // Only ever create the wrapper once to allow animations to happen when something changes.
       this.wrapper = new google.visualization.ChartWrapper({
         container: this.element.nativeElement,
         chartType: this.type,


### PR DESCRIPTION
@FERNman This should fix issue #203. Looks like the function `getPackageForChart` wasn't being used anywhere. I seem to remember this function being used somewhere a while ago but the code must have been refactored. Not sure if there was a reason for not providing a package name when calling the `loadChartPackages` function. However, if such a call was removed before then I'd love to hear it and refactor my proposed fix if needed. Thanks!

Resolves #203 