### PR TITLE
Gantt Chart needs null type to work properly

### DIFF
--- a/libs/angular-google-charts/src/lib/components/chart-base/chart-base.component.ts
+++ b/libs/angular-google-charts/src/lib/components/chart-base/chart-base.component.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs';
 import { ChartErrorEvent, ChartReadyEvent, ChartSelectionChangedEvent } from '../../types/events';
 
 export type Column = string | google.visualization.ColumnSpec;
-export type Row = (string | number | Date)[];
+export type Row = (string | number | Date | null)[];
 
 export interface ChartBase {
   /**


### PR DESCRIPTION
I was working with Gantt Chart and couldn't pass value as null to create a registry without dependencies.
Here the doc URL: https://developers.google.com/chart/interactive/docs/gallery/ganttchart 

![image](https://user-images.githubusercontent.com/22450297/118996637-6d7e7300-b95e-11eb-80f8-fcae5534440c.png)
